### PR TITLE
added put method to order class

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -27,7 +27,7 @@ class JSONServer(HandleRequests):
         view = self.determine_view(url)
 
         try:
-            if view is OrderView:
+            if view.__module__ == "views.OrderView":
                 view.delete(self, url["pk"])
             else:
                 view.delete_put_post(self)
@@ -42,8 +42,8 @@ class JSONServer(HandleRequests):
         view = self.determine_view(url)
 
         try:
-            if view is OrderView:
-                view.update(self, self.get_request_body(), url["pk"])
+            if view.__module__ == "views.OrderView":
+                view.put(self)
             else:
                 view.delete_put_post(self)
         except AttributeError:
@@ -61,7 +61,7 @@ class JSONServer(HandleRequests):
         request_body = self.get_request_body()
         # Invoke the correct method on the view
         try:
-            if view is OrderView:
+            if view.__module__ == "views.OrderView":
                 view.post(self, request_body)
             else:
                 view.delete_put_post(self)

--- a/views/OrderView.py
+++ b/views/OrderView.py
@@ -31,3 +31,8 @@ class OrderView:
             orders = [dict(row) for row in query_results]
             orders_json_array = json.dumps(orders)
             return handler.response(orders_json_array, status.HTTP_200_SUCCESS.value)
+
+    def put(self, handler):
+        return handler.response(
+            "Functionality is not supported", status.HTTP_405_UNSUPPORTED_METHOD.value
+        )


### PR DESCRIPTION
I defined a `.put()` method in the `OrderView` class. The `.do_PUT()` method within my `JSONServer class` now checks to see if `view.__module__` is `"views.OrderView"` and if it is it invokes the `.put()` method which handles all putting or updating interactions with the database regarding orders to send a rejection message that this functionality cannot happen.

"Supported" routes

`/orders` and `/orders/n` attempting `PUT` on either one of these routes will result in a rejection message and 405 status code

## Steps to test
### Orders
1. Pull down the `he-orders-putMethod` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. `PUT` request `http://localhost:8000/orders` or `http://localhost:8000/orders/2` and verify that you get *"Functionality is not supported"* in the response body
5. Also verify that the response code is 405
6.  if you see *"No view for that route"* in the response body and the response code is 405 that is an error, and **NOT** what you're supposed to see